### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "core-js": "^2.6.5",
     "install": "^0.12.2",
-    "npm": "^6.9.0",
     "vue": "^2.6.10",
     "vuejs-auto-complete": "^0.9.0"
   },


### PR DESCRIPTION

Hello t1mwillis!

It seems like you have npm as one of your (dev-) dependency in DiTool.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
